### PR TITLE
|count-1 not recogized tag

### DIFF
--- a/Publisher/nl/personalization.md
+++ b/Publisher/nl/personalization.md
@@ -60,7 +60,7 @@ modifier gebruiken om het aantal subprofielen te tellen waarna je
 van het totaal 1 moet aftrekken omdat wij beginnen met nul.
 
 ```text
-{$profile.collectie[$profile.collectie.last].veldnaam}
+{$profile.collectie[$profile.collectie.length-1].veldnaam}
 ```
 
 Om alle subprofielen weer te geven kun je een foreach functie gebruiken.

--- a/Publisher/nl/personalization.md
+++ b/Publisher/nl/personalization.md
@@ -60,7 +60,7 @@ modifier gebruiken om het aantal subprofielen te tellen waarna je
 van het totaal 1 moet aftrekken omdat wij beginnen met nul.
 
 ```text
-{$profile.collectie[$profile.collectie|count -1].veldnaam}
+{$profile.collectie[$profile.collectie.last].veldnaam}
 ```
 
 Om alle subprofielen weer te geven kun je een foreach functie gebruiken.


### PR DESCRIPTION
.last should result in the same sought after result as |count-1. Publisher states |count-1 is a tag that's not recognized. Syntax error.