### PR TITLE
Update rest-condition-type-field.md

### DIFF
--- a/Publisher/en/restv2/rest-condition-type-field.md
+++ b/Publisher/en/restv2/rest-condition-type-field.md
@@ -37,15 +37,15 @@ $data = array(
     // select field condition
     'type' => 'Field',
 
-    // select field
-    'field' => 'has_children',
+    // select field (using field ID)
+    'field' => 123,
     
     // set value
     'value' => 'yes',
 );
 
 // do the call
-$result = $api->post("rule/id/conditions", $data);
+$result = $api->post("rule/{$id}/conditions", $data);
 
 // print the result
 print_r($result);


### PR DESCRIPTION
the 'field' attribute should be given the ID of the field not the name like the example shows. At least when it comes to submitting this condition to a minirule, I could not get it to work with the field name, but it immediatelly worked with the field ID. 