### PR TITLE
Update rest-post-minirule-conditions.md

### DIFF
--- a/Publisher/en/restv2/rest-post-minirule-conditions.md
+++ b/Publisher/en/restv2/rest-post-minirule-conditions.md
@@ -50,10 +50,12 @@ $data = array(
 	'type' = 'date'
 )
 
-// do the call, and print result
-$api->post("minirule/{$ruleID}/conditions/", array(), $data);
+// do the call
+$result = $api->post("minirule/{$ruleID}/conditions", $data);
 
-// return id of created request if successful
+// print the result
+print_r($result);
+
 ```
 
 The example above requires the [CopernicaRestApi class](rest-php).


### PR DESCRIPTION
Extra array parameter removed and fixed the missing print statement .
I took out the comment on the bottom saying that the ID of created "request" is returned as this is already stated on the top of this page + it is the default response across all of your create requests. 