### PR TITLE
Fix typo in MailerQ json-incomming example

### DIFF
--- a/Mailerq/5.10/json-incoming.md
+++ b/Mailerq/5.10/json-incoming.md
@@ -211,7 +211,7 @@ added to the JSON.
         "domain": "example.com",
         "selector": "dkim",
         "header.i": "fsjfksjfslkdf",
-        "header.b", "sodfidjsfdsjfsfjs"
+        "header.b": "sodfidjsfdsjfsfjs"
     }, {
         "dmarc": "pass",
         "header.from": "whatever@example.com"


### PR DESCRIPTION
A simply typo that I found