### PR TITLE
‘dataonly’ & ‘total’ parameter in GET profiles & subprofiles

### DIFF
--- a/Publisher/en/restv2/rest-get-collection-subprofiles.md
+++ b/Publisher/en/restv2/rest-get-collection-subprofiles.md
@@ -6,24 +6,20 @@ to the following URL:
 `https://api.copernica.com/v2/collection/$id/subprofiles?access_token=xxxx`
 
 The `$id` should be replaced with the numerical identifier of the collection you
-want to fetch the subprofiles of. Since this can be 
-quite a time-consuming call it is possible to use the 'dataonly' property 
-to speed it up.
+want to request subprofiles from.
 
 ## Available parameters
 
 The following parameters can be added to the URL as variables for the call:
 
-* **start**: first subprofile to fetch
-* **limit**: length of the batch to fetch
-* **total**: boolean value to show total of available subprofiles
-* **fields**: optional parameter to only fetch subprofiles with certain field values
-* **orderby**: name or ID of field to sort subprofiles by (default = subprofile ID)
-* **order**: Ascending (asc) or descending (desc) order.
-* **dataonly**: Boolean. If set to true the method will only retrieve the profile data, 
-allowing the call to be processed faster.
+* **start**: First subprofile to fetch.
+* **limit**: Length of the batch to fetch.
+* **total**: Boolean. If set to false, the total number of available subprofiles is not calculated/returned; this can speed up API calls.
+* **fields**: Only fetch subprofiles with certain field values.
+* **orderby**: Name or ID of field to sort subprofiles by (default = subprofile ID).
+* **order**: Whether the subprofiles should be ordered in ascending (asc) or descending (desc) order.
 
-More information on the **start**, **limit** and **total** parameters can be found in 
+More information on the **start**, **limit** and **total** parameters can be found in
 the [article on paging](rest-paging).
 
 The parameter fields can be used to select subprofiles. In case you only want 

--- a/Publisher/en/restv2/rest-get-database-profiles.md
+++ b/Publisher/en/restv2/rest-get-database-profiles.md
@@ -6,22 +6,21 @@ available at the following address:
 `https://api.copernica.com/v2/database/$id/profiles?access_token=xxxx`
 
 In this, `$id` should be replaced by the numerical identifier, the ID, 
-of the database you want to request profiles from. Since this can be 
-quite a time-consuming call it is possible to use the 'dataonly' property 
-to speed it up.
+of the database you want to request profiles from.
 
 ## Available parameters
 
 The following parameters can be added to the URL as variables:
 
-* **fields**: Optional parameter to set conditions for profiles that should be returned.
-* **orderby**: Name or ID of the field you want to use to sort the returned profiles.
-* **order**: Whether the profiles should be ordered in ascending or descending order.
-* **dataonly**: Boolean. If set to true the method will only retrieve the profile data, 
-allowing the call to be processed faster.
+* **start**: First profile to fetch.
+* **limit**: Length of the batch to fetch.
+* **total**: Boolean. If set to false, the total number of available profiles is not calculated/returned; this can speed up API calls.
+* **fields**: Only fetch profiles with certain field values.
+* **orderby**: Name or ID of field to sort profiles by (default = profile ID).
+* **order**: Whether the profiles should be ordered in ascending (asc) or descending (desc) order.
 
-Paging parameters **start**, **limit** and **total** are also supported. More
-information about these parameters can be found in the [article on paging](rest-paging).
+More information on the **start**, **limit** and **total** parameters can be found in
+the [article on paging](rest-paging).
 
 The **fields** parameter can be used to select profiles. For example, 
 if you only want to request profiles where the field “country” equals 

--- a/Publisher/nl/restv2/rest-get-collection-subprofiles.md
+++ b/Publisher/nl/restv2/rest-get-collection-subprofiles.md
@@ -6,25 +6,20 @@ call naar de volgende URL:
 `https://api.copernica.com/v2/collection/$id/subprofiles?access_token=xxxx`
 
 De code `$id` moet je vervangen door de numerieke identifier van de 
-collectie waar je de subprofielen van wilt opvragen. Deze methode kan traag zijn 
-als de database veel profielen bevat. Om deze methode sneller te maken kan 
-er gebruik gemaakt worden van de 'dataonly' parameter.
-
+collectie waar je de subprofielen van wilt opvragen.
 
 ## Beschikbare parameters
 
 De volgende parameters kunnen aan de URL als variabelen worden toegevoegd:
 
-* **start**: eerste profiel dat wordt opgevraagd
-* **limit**: lengte van de batch die wordt opgevraagd
-* **total**: toon wel/niet het totaal aantal beschikbare/matchende profielen
-* **fields**: optionele parameter om alleen subprofielen op te halen die matchen met de opgegeven velden
-* **orderby**: naam of id van het veld waarop je de subprofielen wilt sorteren (standaard is dit het ID van elk subprofiel)
-* **order**: moeten de profielen oplopen of aflopend (asc of desc) worden gesorteerd?
-* **dataonly**: Boolean. Wanneer deze de waarde 'true' heeft wordt alleen de 
-profieldata geladen, waardoor de methode sneller uitgevoerd kan worden.
+* **start**: Eerste subprofiel dat wordt opgevraagd.
+* **limit**: Lengte van de batch die wordt opgevraagd.
+* **total**: Boolean. Wanneer deze waarde 'false' heeft wordt het totaal aantal beschikbare/matchende subprofielen niet berekend/getoond; dit kan API calls sneller maken.
+* **fields**: Vraag alleen subprofielen op die matchen met de opgegeven velden.
+* **orderby**: Naam of ID van het veld waarop je de subprofielen wilt sorteren (standaard is dit het ID van elk subprofiel).
+* **order**: Moeten de subprofielen oplopend of aflopend (asc of desc) worden gesorteerd?
 
-Meer informatie over de betekenis van de **start**, **limit** en **total** parameters 
+Meer informatie over de betekenis van de **start**, **limit** en **total** parameters
 vind je in het [artikel over paging](rest-paging). 
 
 De parameter **fields** kun je gebruiken om subprofielen te selecteren. Als je bijvoorbeeld

--- a/Publisher/nl/restv2/rest-get-database-profiles.md
+++ b/Publisher/nl/restv2/rest-get-database-profiles.md
@@ -6,22 +6,21 @@ en beschikbaar via het volgende adres:
 `https://api.copernica.com/v2/database/$id/profiles?access_token=xxxx`
 
 De code `$id` moet je vervangen door de numerieke identifier of de naam van de 
-database waar je de profielen van wilt opvragen. Deze methode kan traag zijn 
-als de database veel profielen bevat. Om deze methode sneller te maken kan 
-er gebruik gemaakt worden van de 'dataonly' parameter.
+database waar je de profielen van wilt opvragen.
 
 ## Beschikbare parameters
 
 De volgende parameters kunnen aan de URL als variabelen worden toegevoegd:
 
-* **fields**: Optionele parameter om alleen profielen op te halen die matchen met de opgegeven velden.
+* **start**: Eerste profiel dat wordt opgevraagd.
+* **limit**: Lengte van de batch die wordt opgevraagd.
+* **total**: Boolean. Wanneer deze waarde 'false' heeft wordt het totaal aantal beschikbare/matchende profielen niet berekend/getoond; dit kan API calls sneller maken.
+* **fields**: Vraag alleen profielen op die matchen met de opgegeven velden.
 * **orderby**: Naam of ID van het veld waarop je de profielen wilt sorteren (standaard is dit het ID van elk profiel).
-* **order**: Moeten de profielen oplopen of aflopend (asc of desc) worden gesorteerd?
-* **dataonly**: Boolean. Wanneer deze de waarde 'true' heeft wordt alleen de 
-profieldata geladen, waardoor de methode sneller uitgevoerd kan worden.
+* **order**: Moeten de profielen oplopend of aflopend (asc of desc) worden gesorteerd?
 
-De paging parameters **start**, **limit** en **total** parameters worden 
-ook ondersteund. Meer over deze parameters vind je in het [artikel over paging](rest-paging). 
+Meer informatie over de betekenis van de **start**, **limit** en **total** parameters
+vind je in het [artikel over paging](rest-paging).
 
 De parameter **fields** kun je gebruiken om profielen te selecteren. Als je bijvoorbeeld
 alleen profielen wil opvragen waarbij de waarde van het veld "land" gelijk is aan


### PR DESCRIPTION
This is a request/question as well as a PR. But I decided to already do a few edits.

1.

The pages rest-get-database-profiles and rest-get-collection-subprofiles (in both EN and NL) mention the 'dataonly' parameter fairly prominently, including the notion that it can speed up API queries. But I have no clue what it does exactly and there are no examples. If I pass it, I see exactly nothing change: all 'metadata' (start, limit, total, etc) still get returned , and so does both the field data and non-field parameters (e.g. secret).

My guess (given point 2) is that this parameter just doesn't exist. Please ask your tech staff what it does, and if it does, what is the exact difference / why is it not true by default. Because people will only implement it if they know exactly what it does. If it does not exist: delete it.

2.

There is also the 'total' parameter. And
* The 'rest-paging' page says "Please note that printing the total is completely optional and choosing not to do so might speed up your calls a lot." (which sounds a lot like 'dataonly').
* That "speed" part is not mentioned in the rest-get-database-profiles / rest-get-collection-subprofiles at all. If it indeed can speed things up (or at the least can ease stress on your servers; I have not seen it be significantly faster) then that should be mentioned more prominently.

The attached PR:
1. removes mentions of 'dataonly'
2. mentions the possible speedup for 'total = false' on rest-get-database-profiles / rest-get-collection-subprofiles, and explicitly adds start/limit/total to the list of parameters (which was already done on subprofile pages but not on profile pages).
3. Does some miscellaneous formatting which was inconsistent across pages. (Capitalization, superfluous mentions of "Optional" while in fact all parameters are optional, ...)

Note **this is not the full amount of work to be done**. There are also:
* rest-get-view-profiles - curiously, the NL version has never mentioned the 'dataonly' parameter - but it could use the extra wording on 'total' (and reformatting). The EN version needs the start/limit/total pages added just like the 'profile' versions.
* rest-get-miniview-subprofiles - the NL and EN version both mention the 'dataonly' parameter and both do not have a bulleted parameters list. The EN version mentions start, limit and total parameters in a sentence but the NL version does not.

(I don't know about how views and miniviews work, myself.

*EDIT*: I just spotted the rest-get-miniview-views page. That likely needs some similar work but, like rest-get-miniview-subprofiles, I don't know exactly which parameters are valid. Also... for the EN page, the title mentions "databases" instead of views, and the 'total' parameter mentions "interests" instead. I don't even.)