### PR TITLE
Say 'orderby' instead of 'order', in relevant places.

### DIFF
--- a/Publisher/en/restv2/rest-get-collection-subprofiles.md
+++ b/Publisher/en/restv2/rest-get-collection-subprofiles.md
@@ -26,17 +26,19 @@ allowing the call to be processed faster.
 More information on the **start**, **limit** and **total** parameters can be found in 
 the [article on paging](rest-paging).
 
-The parameter fields can be used to select subprofiles. In case you only want 
+The **fields** parameter can be used to select subprofiles. In case you only want 
 to fetch the profiles where the value of the field "country" is equal to 
 "Netherlands" you can assert this in the *fields* field. For more information on 
 using the *fields* parameter you can consult the [article on the fields parameter](rest-fields-parameter).
 
-The variable order can be set to the name or the ID of a field to sort the 
-subprofiles by it. There are also three special values to sort by:
+The **orderby** parameter can have the name or the ID of a field assigned to 
+it. When you do so, subprofiles are sorted by the value in that field. 
+Instead of a field to sort on, you can also assign one of the following 
+special values to **orderby**:
 
-* **id**: default value, sort subprofiles by ID
-* **random**: return subprofiles in a random order
-* **modified**: subprofiles are ordered by last modified
+* **id**: The default value; profiles are ordered based on their ID.
+* **random**: Subprofiles are randomly ordered.
+* **modified**: Subprofiles are ordered based on the *modified* timestamp.
 
 ## Returned fields
 

--- a/Publisher/en/restv2/rest-get-database-profiles.md
+++ b/Publisher/en/restv2/rest-get-database-profiles.md
@@ -29,10 +29,10 @@ if you only want to request profiles where the field “country” equals
 this parameter can be found in the 
 [article on the “fields” parameter](rest-fields-parameter).
 
-The **order** variable can have the name or the ID of a field assigned to 
+The **orderby** parameter can have the name or the ID of a field assigned to 
 it. When you do so, profiles are sorted by the value in that field. 
 Instead of a field to sort on, you can also assign one of the following 
-special values to “order”:
+special values to **orderby**:
 
 * **id**: The default value, profiles are ordered based on their ID
 * **random**: Profiles are randomly ordered

--- a/Publisher/en/restv2/rest-get-view-profiles.md
+++ b/Publisher/en/restv2/rest-get-view-profiles.md
@@ -25,9 +25,10 @@ use this parameter to only fetch profiles for which the field "country" equals
 "France". More information about using this parameter can be found in our
 [article about this fields parameter](./rest-fields-parameter.md).
 
-You can assign the name or numeric identifier of a field to the parameter **order**.
-This will order the profiles on the given field.
-Besides a name or ID, you can also pass a couple of special values to this parameter:
+The **orderby** parameter can have the name or the ID of a field assigned to 
+it. When you do so, profiles are sorted by the value in that field. 
+Instead of a field to sort on, you can also assign one of the following 
+special values to **orderby**:
 
 * **id**: The default value, profiles are ordered based on their ID
 * **random**: Profiles are randomly ordered

--- a/Publisher/nl/restv2/rest-get-collection-subprofiles.md
+++ b/Publisher/nl/restv2/rest-get-collection-subprofiles.md
@@ -33,10 +33,10 @@ alleen subprofielen wil opvragen waarbij de waarde van het veld "land" gelijk is
 gebruik van deze **fields** parameter kun je vinden in een 
 [artikel over de fields parameter](rest-fields-parameter).
 
-De variabele **order** kun je de naam of het id van een veld geven. De profielen
+De parameter **orderby** kun je de naam of het id van een veld geven. De subprofielen
 worden dan gesorteerd aan de hand van dit veld. In plaats van de naam of id van het
 veld waarop je wilt sorteren, kun je ook een aantal speciale waardes aan de 
-parameter *order* geven:
+parameter **orderby** geven:
 
 * **id**: dit is de standaardwaarde, subprofielen worden gesorteerd aan de hand van het id
 * **random**: de subprofielen worden in willekeurige volgorde teruggegeven

--- a/Publisher/nl/restv2/rest-get-database-profiles.md
+++ b/Publisher/nl/restv2/rest-get-database-profiles.md
@@ -29,10 +29,10 @@ alleen profielen wil opvragen waarbij de waarde van het veld "land" gelijk is aa
 gebruik van deze *fields* parameter kun je vinden in een 
 [artikel over de fields parameter](rest-fields-parameter).
 
-De variabele **order** kun je de naam of het ID van een veld geven. De profielen
+De parameter **orderby** kun je de naam of het ID van een veld geven. De profielen
 worden dan gesorteerd aan de hand van dit veld. In plaats van de naam of ID van het
 veld waarop je wilt sorteren, kun je ook een aantal speciale waardes aan de 
-parameter **order** geven:
+parameter **orderby** geven:
 
 * **id**: dit is de standaardwaarde, profielen worden gesorteerd aan de hand van het ID.
 * **random**: de profielen worden in willekeurige volgorde teruggegeven.

--- a/Publisher/nl/restv2/rest-get-view-profiles.md
+++ b/Publisher/nl/restv2/rest-get-view-profiles.md
@@ -22,16 +22,16 @@ De volgende parameters kunnen aan de URL als variabelen worden toegevoegd:
 Meer informatie over de betekenis van de **start**, **limit** en **total** parameters 
 vind je in het [artikel over paging](rest-paging). 
 
-De parameter *fields* kun je gebruiken om profielen te selecteren. Als je bijvoorbeeld
+De parameter **fields** kun je gebruiken om profielen te selecteren. Als je bijvoorbeeld
 alleen profielen wil opvragen waarbij de waarde van het veld "land" gelijk is aan
 "Nederland", kun je dat opgeven in het veld "fields". Meer informatie over het
 gebruik van deze *fields* parameter kun je vinden in een 
 [artikel over de fields parameter](rest-fields-parameter).
 
-De variabele **order** kun je de naam of het ID van een veld geven. De profielen
+De parameter **orderby** kun je de naam of het ID van een veld geven. De profielen
 worden dan gesorteerd aan de hand van dit veld. In plaats van de naam of ID van het
 veld waarop je wilt sorteren, kun je ook een aantal speciale waardes aan de 
-parameter *order* geven:
+parameter **orderby** geven:
 
 * **id**: dit is de standaardwaarde, profielen worden gesorteerd aan de hand van het ID.
 * **random**: de profielen worden in willekeurige volgorde teruggegeven.


### PR DESCRIPTION
The documentation fairly consistently talks about the 'order' parameter, where it means to explain what the 'orderby' parameter does.