### PR TITLE
Fix documentation for put-profile-subprofiles

### DIFF
--- a/Publisher/en/restv2/rest-put-database-profiles.md
+++ b/Publisher/en/restv2/rest-put-database-profiles.md
@@ -11,7 +11,7 @@ should be sent in the request body.
 
 Please keep in mind that this is a HTTP PUT request. This method is an
 exception to the rule that the Copernica REST API makes no distinction between
-HTTP POST and HTTP GET calls. For this method you must use HTTP PUT. If you
+HTTP POST and HTTP PUT calls. For this method you must use HTTP PUT. If you
 send a POST request, you [would be making a brand new profile](./rest-post-database-profiles.md). 
 
 ## Supported parameters
@@ -25,10 +25,10 @@ the request body. You can pass the following parameters to the URL:
 If you set this to 1, the method immediately returns and proceeds in 
 the background with updating profiles.
 
-The **fields** parameter is required. By passing this parameter to the the method
-you prevent that you overwrite all your profiles with a single API call. Only
-the profiles that match with the supplied fields are modified. You can find more
-information about this parameter in [the article about this parameter](./rest-fields-parameter.md).
+The **fields** parameter is required, to prevent overwriting all profiles in a
+database with a single API call. Only the profiles that match with the supplied
+fields are modified. You can find more information about this parameter in
+[the article about this parameter](./rest-fields-parameter.md).
 
 If there are no profiles that match the supplied **fields**, and when you have set
 **create** to 1, the REST API creates a brand new profile using
@@ -41,7 +41,7 @@ to immediately return, while it updates the profiles in the background.
 ## Body data
 
 Besides the parameters that you append to the URL, you must also include a
-request body in the POST request. The body has two optional components: 
+request body in the PUT request. The body has two optional components:
 'fields' and 'interests'. Both will be added to the new profile. The interests 
 can be added from a list ("football") or with an associative array 
 ("football" => 1, "baseball" => 0). Fields must be an associative array.

--- a/Publisher/en/restv2/rest-put-profile-subprofiles.md
+++ b/Publisher/en/restv2/rest-put-profile-subprofiles.md
@@ -1,20 +1,41 @@
 # REST API: PUT profile subprofiles
 
-To update or add subprofiles to a profile an HTTP PUT request can be sent to the following URL:
+If you want to modify multiple subprofiles with a single call to the API, you
+can send a HTTP PUT request to the following URL:
 
-`https://api.copernica.com/v2/subprofile/$id/fields?access_token=xxxx`
+`https://api.copernica.com/v2/profile/$id/subprofiles/$id?access_token=xxxx`
 
-The `$id` should be replaced with the ID of the subprofile you want to update or add
-information to.
+The first `$id` should be replaced with the ID of the profile which the
+subprofiles are linked to. The second `$id` should be replaced with the ID or
+name of collection the collection containing the subprofiles. The new
+field values should be sent in the request body.
 
-## Available data
-The new field values need to be added to the body of the message. 
-This data simply consists of the existing field names on the subprofile 
-you want to change and their new values. If you send your data in JSON format, 
-you’ll need to create an object with field names as keys and field values as values.
-If, however, you’re using a traditional x-www-form-urlencoded format, 
-the variables should contain the names of the fields you want to change, 
-and the values should be the new field values.
+Please keep in mind that this is a HTTP PUT request. This method is an
+exception to the rule that the Copernica REST API makes no distinction between
+HTTP POST and HTTP PUT calls. For this method you must use HTTP PUT. If you
+send a POST request, you [would be making a brand new subprofile](./rest-post-profile-subprofiles.md). 
+
+## Supported parameters
+
+You must use two different ways to pass data to this method; through the URL and
+the request body. You can pass the following parameters to the URL:
+
+* **fields**: required parameter to select the subprofiles that are going to be modified
+* **create**: boolean parameter that determines whether to create a new subprofile if none exist.
+
+The **fields** parameter is required, to prevent overwriting all profiles in a
+database with a single API call. Only the profiles that match with the supplied
+fields are modified. You can find more information about this parameter in
+[the article about this parameter](./rest-fields-parameter.md).
+
+If there are no subprofiles that match the supplied **fields**, and when you have set
+**create** to 1, the REST API creates a brand new subprofile using
+the fields passed in the HTTP request body.
+
+## Body data
+
+The field names and new values of the subprofiles' fields that should be updated
+must be passed in the data body.
 
 ## PHP example
 
@@ -27,15 +48,21 @@ require_once('copernica_rest_api.php');
 // change this into your access token
 $api = new CopernicaRestAPI("your-access-token", 2);
 
+// parameters for subprofile selection
+$parameters = array(
+    'fields'    =>  array("customerid==4567"),
+    'create'    =>  0
+);
+
 // data to pass to the call, the new fields
 $data = array(
     'firstname' =>  'John',
     'lastname'  =>  'Doe',
     'email'     =>  'johndoe@example.com'
 );
-  
+
 // do the call
-$api->put("subprofile/{$subprofileID}/fields", $data);
+$api->put("profile/{$profileID}/subprofiles/{$collectionID}", $data);
 ```
 
 The example above requires the [CopernicaRestApi class](rest-php).
@@ -43,7 +70,6 @@ The example above requires the [CopernicaRestApi class](rest-php).
 ## More information
 
 * [Overview of all REST API calls](rest-api)
-* [PUT profile interests](rest-put-profile-interests)
-* [POST database profile](rest-post-database-profiles)
-* [GET subprofile](rest-get-subprofile)
-* [POST profile subprofile](rest-post-profile-subprofiles)
+* [PUT database profiles](rest-put-database-profiles)
+* [PUT subprofile fields](./rest-put-subprofile-fields)
+* [POST profile subprofiles](rest-post-profile-subprofiles)

--- a/Publisher/nl/restv2/rest-post-profile-subprofiles.md
+++ b/Publisher/nl/restv2/rest-post-profile-subprofiles.md
@@ -5,9 +5,9 @@ kun je een HTTP POST request sturen naar de volgende URL:
 
 `https://api.copernica.com/v2/profile/$id/subprofiles/$id?access_token=xxxx`
 
-De eerste `$id` moet je vervangen door de numerieke identifier van het profiel 
+De eerste `$id` moet vervangen worden door de numerieke identifier van het profiel
 waaraan je een subprofiel wil toevoegen en de tweede `$id` moet vervangen worden
-met de identifier of naam van de collectie waarin je het subprofiel wil toevoegen.
+door de identifier of naam van de collectie waarin je het subprofiel wil toevoegen.
 De inhoud van het subprofiel kun je in de message body plaatsen.
 
 ## Body data
@@ -32,7 +32,7 @@ require_once('copernica_rest_api.php');
 // verander dit naar je access token
 $api = new CopernicaRestAPI("your-access-token", 2);
 
-// data voor de methode
+// velden voor het nieuwe subprofiel
 $data = array(
     'firstname' =>  'John',
     'lastname'  =>  'Doe',

--- a/Publisher/nl/restv2/rest-put-database-profiles.md
+++ b/Publisher/nl/restv2/rest-put-database-profiles.md
@@ -24,15 +24,15 @@ het kopje body data. Aan de URL kun je de volgende parameters toevoegen:
 * **create**: boolean parameter om aan te geven dat een nieuw profiel moet worden aangemaakt indien er geen matchende profielen zijn
 * **async**: boolean parameter om aan te geven dat de profiel asynchroon moeten worden aangemaakt. De API methode returned dan onmiddellijk, en gaat in de achtergrond verder met het bijwerken van profielen
 
-De **fields** parameter is verplicht. Deze parameter voorkomt dat je met een
-enkele API call alle profielen in de database bijwerkt. Alleen de matchende
-profielen worden bijgewerkt. Meer informatie over het gebruik van deze **fields**
+De **fields** parameter is verplicht, om te voorkomen dat een enkele API call
+alle profielen in de database kan bijwerken. Alleen de matchende profielen
+worden bijgewerkt. Meer informatie over het gebruik van deze **fields**
 parameter kun je vinden in een
 [artikel over de fields parameter](rest-fields-parameter).
 
-Als er geen matchende profielen zijn, dat kun je met de **create** parameter
-aangeven dat een nieuw profiel moet worden aangemaakt op basis van de meegegeven
-request data.
+Met de **create** parameter kun je aangeven dat als er geen matchende profielen
+zijn, een nieuw profiel moet worden aangemaakt op basis van de meegegeven
+body data.
 
 Het bijwerken van meerdere profielen kan een tijdrovende operatie zijn, met name
 als er veel matchende profielen zijn. Als je niet zo lang op een API
@@ -42,7 +42,7 @@ dan onmiddellijk, terwijl de operatie in de achtergrond wordt voortgezet.
 ## Body data
 
 Naast de parameters die je aan de URL meegeeft, moet je ook body data aan het
-POST request toevoegen. In de body van het verzoek kun je twee optionele arrays meegeven: 
+PUT request toevoegen. In de body van het verzoek kun je twee optionele arrays meegeven:
 'fields' bevat de velden voor het profiel en 'interests' de interesses. 
 De interesses kunnen als een associatieve array ('voetbal' => 1, 'honkbal' => 0) 
 of als een lijst ('voetbal') meegegeven worden. De profielvelden moeten 
@@ -78,7 +78,7 @@ $parameters = array(
     'create'    =>  0
 );
 
-// velden voor het nieuwe profiel
+// velden die bewerkt moeten worden
 $fields = array(
     'firstname' =>  'John',
     'lastname'  =>  'Doe',

--- a/Publisher/nl/restv2/rest-put-profile-subprofiles.md
+++ b/Publisher/nl/restv2/rest-put-profile-subprofiles.md
@@ -3,15 +3,42 @@
 Je kunt een subprofiel bewerken door een HTTP PUT request sturen naar de volgende 
 URL:
 
-`https://api.copernica.com/v2/subprofile/$id/fields?access_token=xxxx`
+`https://api.copernica.com/v2/profile/$id/subprofiles/$id?access_token=xxxx`
 
-De code `$id` moet je vervangen door de numerieke identifier van het subprofiel 
-waaraan je een data wilt toevoegen De inhoud van het subprofiel kun je in de message body plaatsen.
+De eerste `$id` moet vervangen worden door de numerieke identifier van het
+profiel waaraan de subprofielen gekoppeld zijn. De tweede `$id` moet vervangen
+worden door de identifier of naam van de collectie die de subprofieldn bevat.
+De inhoud van het subprofiel kun je in de message body plaatsen.
+
+Let goed op dat je daadwerkelijk een PUT call naar de server stuurt. Hoewel
+de meeste API methodes precies hetzelfde werken of je nou HTTP POST of PUT
+gebruikt, geldt dit niet voor deze methode. HTTP PUT is vereist. Als je toch
+een POST zou sturen, dan [maak je een nieuw subprofiel aan](rest-post-profile-subprofiles).
+
+## Beschikbare parameters
+
+Bij deze methodes zijn er twee verplichte manieren om data mee te geven;
+via de URL en als body van het HTTP request. Over de body vind je meer onder
+het kopje body data. Aan de URL kun je de volgende parameters toevoegen:
+
+* **fields**: verplichte parameter om de subprofielen te selecteren die worden aangepast
+* **create**: boolean parameter om aan te geven dat een nieuw subprofiel moet worden aangemaakt indien er geen matchende profielen zijn
+
+De **fields** parameter is verplicht, om te voorkomen dat een enkele API call
+alle profielen met de combinatie van profiel/collectie kan bijwerken.
+Alleen de matchende profielen worden bijgewerkt. Meer informatie over het
+gebruik van deze **fields** parameter kun je vinden in een
+[artikel over de fields parameter](rest-fields-parameter).
+
+Met de **create** parameter kun je aangeven dat als er geen matchende profielen
+zijn, een nieuw subprofiel moet worden aangemaakt op basis van de meegegeven
+body data.
 
 ## Body data
 
-Je kunt een field bewerken door properties mee te geven aan de data
-array.
+De veldnamen en nieuwe waarden van de te bewerken subprofielvelden moeten
+worden meegegeven in de body. 
+
 
 ## Voorbeeld in PHP
 
@@ -24,7 +51,14 @@ require_once('copernica_rest_api.php');
 // verander dit naar je access token
 $api = new CopernicaRestAPI("your-access-token", 2);
 
-// data voor de methode
+// parameters voor het selecteren van subprofielen
+$parameters = array(
+    'fields'    =>  array("klantID==4567"),
+    'async'     =>  1,
+    'create'    =>  0
+);
+
+// velden die bewerkt moeten worden
 $data = array(
     'firstname' =>  'John',
     'lastname'  =>  'Doe',
@@ -32,7 +66,7 @@ $data = array(
 );
 
 // voer het verzoek uit
-$api->put("subprofile/{$subprofielID}/fields", $data);
+$api->put("profile/{$profielID}/subprofiles/{$collectieID}", $data);
 ```
 
 Dit voorbeeld vereist de [REST API klasse](rest-php).
@@ -40,7 +74,6 @@ Dit voorbeeld vereist de [REST API klasse](rest-php).
 ## Meer informatie
 
 * [Overzicht van alle API calls](rest-api)
-* [POST profiel subprofielen](rest-post-profile-subprofiles)
-* [PUT profiel interesses](rest-put-profile-interests)
-* [GET subprofiel](rest-get-subprofile)
-* [DELETE subprofiel](rest-delete-subprofile)
+* [Meerdere profielen bewerken in een database](rest-put-database-profiles)
+* [Subprofielvelden bijwerken](rest-put-subprofile-fields)
+* [Subprofiel toevoegen aan een profiel/collectie](rest-post-profile-subprofiles)


### PR DESCRIPTION
The documentation for PUT profile/$id/subprofiles/$id is wrong. It's a page copied from put-profile-fields but the contents were (almost) unchanged from the original.

Having this page be correct is significant, because it's tricky to understand what is the difference between PUT and POST.

I copied and changed the information from the analogous "PUT database/$id/profiles" page, and where profiles differ from subprofiles I coped the changes from the "POST profile/$id/subprofiles/$id" into it. Some edits were also made to the source pages, for mistakes/grammar.

**Notes:** I did not copy certain info from the "PUT database/$id/profiles" page:

* The documentation about the **async** parameter - because I don't know if this call has the same async functionality. One of your developers will be able to tell you that.
* The parts about the return value being different if a new subprofile is created - because this isn't the case. I think that is a bug and I will file a support ticket.