### PR TITLE
Add second $id to the URL for profile/$id/subprofiles

### DIFF
--- a/Publisher/en/restv2/rest-api.md
+++ b/Publisher/en/restv2/rest-api.md
@@ -186,9 +186,9 @@ like your customers or orders. The relevant API calls can be found below.
 | GET    | [api.copernica.com/v2/profile/$id](./rest-get-profile)                                               | Fetch the profile information                         |
 | PUT    | [api.copernica.com/v2/profile/$id](./rest-put-profile)                                               | Update the profile information                        |
 | DELETE | [api.copernica.com/v2/profile/$id](./rest-delete-profile)                                            | Delete a profile                                      |
-| GET    | [api.copernica.com/v2/profile/$id/subprofiles](./rest-get-profile-subprofiles)                       | Fetch all profile subprofiles                         |
-| POST   | [api.copernica.com/v2/profile/$id/subprofiles](./rest-post-profile-subprofiles)                      | Create a new profile subprofile                       |
-| PUT    | [api.copernica.com/v2/profile/$id/subprofiles](./rest-put-profile-subprofiles)                       | Update one or multiple profile subprofiles            |
+| GET    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-get-profile-subprofiles)                       | Fetch all profile subprofiles                         |
+| POST   | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-post-profile-subprofiles)                      | Create a new profile subprofile                       |
+| PUT    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-put-profile-subprofiles)                       | Update one or multiple profile subprofiles            |
 | GET    | [api.copernica.com/v2/profile/$id/fields](./rest-get-profile-fields)                                 | Fetch all profile fields                              |
 | PUT    | [api.copernica.com/v2/profile/$id/fields](./rest-put-profile-fields)                                 | Update one or multiple profile fields                 |
 | GET    | [api.copernica.com/v2/profile/$id/interests](./rest-get-profile-interests)                           | Fetch all profile interests                           |

--- a/Publisher/nl/restv2/rest-api.md
+++ b/Publisher/nl/restv2/rest-api.md
@@ -188,9 +188,9 @@ in de onderstaande tabel.
 | GET    | [api.copernica.com/v2/profile/$id](./rest-get-profile)                                               | Opvragen van profiel informatie                                   |
 | PUT    | [api.copernica.com/v2/profile/$id](./rest-put-profile)                                               | Updaten van profiel informatie                                    |
 | DELETE | [api.copernica.com/v2/profile/$id](./rest-delete-profile)                                            | Verwijderen van een profiel                                       |
-| GET    | [api.copernica.com/v2/profile/$id/subprofiles](./rest-get-profile-subprofiles)                       | Opvragen van alle profiel subprofielen                            |
-| POST   | [api.copernica.com/v2/profile/$id/subprofiles](./rest-post-profile-subprofiles)                      | Aanmaken van een nieuw profiel subprofiel                         |
-| PUT    | [api.copernica.com/v2/profile/$id/subprofiles](./rest-put-profile-subprofiles)                       | Updaten van een of meerdere profiel subprofielen                  |
+| GET    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-get-profile-subprofiles)                       | Opvragen van alle profiel subprofielen                            |
+| POST   | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-post-profile-subprofiles)                      | Aanmaken van een nieuw profiel subprofiel                         |
+| PUT    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-put-profile-subprofiles)                       | Updaten van een of meerdere profiel subprofielen                  |
 | GET    | [api.copernica.com/v2/profile/$id/fields](./rest-get-profile-fields)                                 | Opvragen van alle profiel velden                                  |
 | PUT    | [api.copernica.com/v2/profile/$id/fields](./rest-put-profile-fields)                                 | Updaten van een of meerdere profiel velden                        |
 | GET    | [api.copernica.com/v2/profile/$id/interests](./rest-get-profile-interests)                           | Opvragen van alle profiel interesses                              |


### PR DESCRIPTION
On the overview page for the REST API methods, a second $id should be added to the profile/$id/subprofiles calls
* because they are all mandatory.
* because the URL documented on the top of the specific pages also has the second ID (except for the PUT page, but that should be completely overhauled; see #64).
* because then it will be easier to grasp, from this overview, what is the difference between (GET) collection/$id/subprofiles and profile/$id/subprofiles/$id - which confused me for a while.
* because this is not the only place where you have two IDs. See e.g. database/$id/field/$id