### PR TITLE
Get subprofiles: link from 1 method to another.

### DIFF
--- a/Publisher/en/restv2/rest-api.md
+++ b/Publisher/en/restv2/rest-api.md
@@ -186,9 +186,9 @@ like your customers or orders. The relevant API calls can be found below.
 | GET    | [api.copernica.com/v2/profile/$id](./rest-get-profile)                                               | Fetch the profile information                         |
 | PUT    | [api.copernica.com/v2/profile/$id](./rest-put-profile)                                               | Update the profile information                        |
 | DELETE | [api.copernica.com/v2/profile/$id](./rest-delete-profile)                                            | Delete a profile                                      |
-| GET    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-get-profile-subprofiles)                       | Fetch all profile subprofiles                         |
-| POST   | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-post-profile-subprofiles)                      | Create a new profile subprofile                       |
-| PUT    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-put-profile-subprofiles)                       | Update one or multiple profile subprofiles            |
+| GET    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-get-profile-subprofiles)                   | Fetch subprofiles for a profile                       |
+| POST   | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-post-profile-subprofiles)                  | Create a new subprofile                               |
+| PUT    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-put-profile-subprofiles)                   | Update one or multiple subprofiles                    |
 | GET    | [api.copernica.com/v2/profile/$id/fields](./rest-get-profile-fields)                                 | Fetch all profile fields                              |
 | PUT    | [api.copernica.com/v2/profile/$id/fields](./rest-put-profile-fields)                                 | Update one or multiple profile fields                 |
 | GET    | [api.copernica.com/v2/profile/$id/interests](./rest-get-profile-interests)                           | Fetch all profile interests                           |

--- a/Publisher/en/restv2/rest-get-collection-subprofiles.md
+++ b/Publisher/en/restv2/rest-get-collection-subprofiles.md
@@ -24,6 +24,8 @@ will speed up the call.
 * **dataonly**: Boolean. If set to true the method will only retrieve the ID, fields, collection ID, 
 profile ID and modified date to speed up the call.
 
+There is no parameter to set a condition for profile ID. There is a separate GET call to [fetch subprofiles for a profile](rest-get-profile-subprofiles).
+
 ### Paging
 
 More information on the **start**, **limit** and **total** parameters can be found in 
@@ -112,3 +114,4 @@ The example above requires the [CopernicaRestApi class](rest-php).
 
 * [List of all API calls](rest-api)
 * [GET collection profile identifiers](rest-get-collection-subprofiles)
+* [GET profile subprofiles](rest-get-profile-subprofiles)

--- a/Publisher/nl/restv2/rest-api.md
+++ b/Publisher/nl/restv2/rest-api.md
@@ -188,9 +188,9 @@ in de onderstaande tabel.
 | GET    | [api.copernica.com/v2/profile/$id](./rest-get-profile)                                               | Opvragen van profiel informatie                                   |
 | PUT    | [api.copernica.com/v2/profile/$id](./rest-put-profile)                                               | Updaten van profiel informatie                                    |
 | DELETE | [api.copernica.com/v2/profile/$id](./rest-delete-profile)                                            | Verwijderen van een profiel                                       |
-| GET    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-get-profile-subprofiles)                       | Opvragen van alle profiel subprofielen                            |
-| POST   | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-post-profile-subprofiles)                      | Aanmaken van een nieuw profiel subprofiel                         |
-| PUT    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-put-profile-subprofiles)                       | Updaten van een of meerdere profiel subprofielen                  |
+| GET    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-get-profile-subprofiles)                   | Opvragen van subprofielen voor een profiel                        |
+| POST   | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-post-profile-subprofiles)                  | Aanmaken van een nieuw subprofiel                                 |
+| PUT    | [api.copernica.com/v2/profile/$id/subprofiles/$id](./rest-put-profile-subprofiles)                   | Updaten van een of meerdere subprofielen                          |
 | GET    | [api.copernica.com/v2/profile/$id/fields](./rest-get-profile-fields)                                 | Opvragen van alle profiel velden                                  |
 | PUT    | [api.copernica.com/v2/profile/$id/fields](./rest-put-profile-fields)                                 | Updaten van een of meerdere profiel velden                        |
 | GET    | [api.copernica.com/v2/profile/$id/interests](./rest-get-profile-interests)                           | Opvragen van alle profiel interesses                              |

--- a/Publisher/nl/restv2/rest-get-collection-subprofiles.md
+++ b/Publisher/nl/restv2/rest-get-collection-subprofiles.md
@@ -24,6 +24,8 @@ De methode is sneller wanneer dit op 'false' staat.
 * **dataonly**: Boolean. Wanneer deze de waarde 'true' heeft worden alleen de ID, velden, 
 collectie ID, profiel ID en datum van laatste aanpassing opgevraagd om de methode sneller te maken.
 
+Er is geen parameter om te matchen op profiel. Er is een aparte call voor het [opvragen van subprofielen voor een profiel](rest-get-profile-subprofiles).
+
 ### Paging
 
 Meer over de **start**, **limit** en **total** parameters vind je in het [artikel over paging](rest-paging). 
@@ -109,6 +111,7 @@ Dit voorbeeld vereist de [REST API klasse](rest-php).
 
 * [Overzicht van alle API calls](rest-api)
 * [Opvragen van profiel ID's](rest-get-collection-profileids)
+* [Opvragen van subprofielen voor een profiel](rest-get-profile-subprofiles)
 * [Subprofiel toevoegen aan een collectie](rest-post-collection-subprofiles)
 * [Subprofiel bijwerken](rest-put-subprofile-fields)
 * [Subprofiel verwijderen](rest-delete-subprofile)


### PR DESCRIPTION
This is my last PR / suggestion'; it's small. I held it (commit 1) back because it wasn't super important, but it was separate from the other issues I filed - and there would be merge conflicts.

Commit 1:

As a not-yet-experienced user I got a bit lost in the various subprofile calls. This is one thing were I lost some time because I didn't see it at first: "but how do you filter on profile? Oh wait... that's another call."

Added commit 2:

This is a tweak of #65 which I did not spot when I was adding the second $id to GET profile/$id/suprofiles: one reason it used to be confusing is that the description says "*all* a profile's subprofiles", which isn't true.

Also I did minor editing of the next two lines; if you don't agree you can revert that. Also, sorry for messing up your table layout :) which I didn't see before.