### PR TITLE
[MailerQ] Explain configuration overrides

### DIFF
--- a/Mailerq/5.13/configuration.md
+++ b/Mailerq/5.13/configuration.md
@@ -7,10 +7,9 @@ three different ways:
 2. Via a command-line option.
 3. Via an environment variable.
 
-When a configuration option is given on the command-line, it overrides the
-value specified in the configuration file. Similarly, when a configuration
-option is set in an environment variable, it overrides both the configuration
-file as well as the command-line option.
+When an environment variable is set, it overrides the value specified in the
+configuration file. Similarly, when a command-line option is provided, it
+overrides both the configuration file as well as the environment variable.
 
 ## Overridability
 

--- a/Mailerq/5.13/configuration.md
+++ b/Mailerq/5.13/configuration.md
@@ -14,12 +14,10 @@ file as well as the command-line option.
 
 ## Overridability
 
-Overridability of keys follows a simple pattern. In the rest of this
-documentation, we only denote the name of the configuration key as specified in
-the configuration file. If you want to override such a key via the
-command-line, add two dashes in front of the key name. If you want to override
-the key via an environment variable, uppercase the key, prepend it with
-`MAILERQ_`, and replace dashes with underscores.
+Overridability of keys follows a simple pattern. If you want to override such a
+key via the command-line, add two dashes in front of the key name. If you want
+to override the key via an environment variable, uppercase the key, prepend the
+string `MAILERQ_` to it, and replace dashes with underscores.
 
 As an example, the configuration key `rabbitmq-address` can also be given on
 the command-line by running
@@ -36,10 +34,13 @@ an environment variable:
 MAILERQ_RABBITMQ_ADDRESS=amqp://rabbit.example.com mailerq
 ```
 
-The above will cause MailerQ to use `amqp://rabbit.example.com`. If you supply
-both, then the environment variable "wins".
+The above will cause MailerQ to use `rabbit.example.com`. If you supply both,
+then the environment variable "wins".
 
 ## In-depth settings
+
+In the rest of this documentation, we only denote the name of the configuration
+key as specified in the configuration file.
 
 The documentation for the various options is split up in different sections.
 Please select the section that you're interested in or  find the desired

--- a/Mailerq/5.13/configuration.md
+++ b/Mailerq/5.13/configuration.md
@@ -1,13 +1,49 @@
-# Configuration file
+# Configuration
 
-MailerQ reads its configuration from the "/etc/mailerq/config.txt" config 
-file. This file holds configuration options for the connection to RabbitMQ, 
-NoSQL storage engine and database (MySql, Sqlite or PostgreSql) and other 
-options for MailerQ itself.
+MailerQ has lots of configuration options. Each option can be supplied in
+three different ways:
 
-The config file, and the documentation, has been split up in different
-sections. Please select the section that you're interested in or 
-find the desired setting in the [A-Z settings overview](settings-alphabetical).
+1. Via a configuration file. Its location is `/etc/mailerq/config.txt`.
+2. Via a command-line option.
+3. Via an environment variable.
+
+When a configuration option is given on the command-line, it overrides the
+value specified in the configuration file. Similarly, when a configuration
+option is set in an environment variable, it overrides both the configuration
+file as well as the command-line option.
+
+## Overridability
+
+Overridability of keys follows a simple pattern. In the rest of this
+documentation, we only denote the name of the configuration key as specified in
+the configuration file. If you want to override such a key via the
+command-line, add two dashes in front of the key name. If you want to override
+the key via an environment variable, uppercase the key, prepend it with
+`MAILERQ_`, and replace dashes with underscores.
+
+As an example, the configuration key `rabbitmq-address` can also be given on
+the command-line by running
+
+```bash
+mailerq --rabbitmq-address=amqp://rabbit.example.com
+```
+
+MailerQ will then use `rabbit.example.com` for its RabbitMQ server, instead of
+the value that's given in `/etc/mailerq/config.txt`. Similarly, you can provide
+an environment variable:
+
+```bash
+MAILERQ_RABBITMQ_ADDRESS=amqp://rabbit.example.com mailerq
+```
+
+The above will cause MailerQ to use `amqp://rabbit.example.com`. If you supply
+both, then the environment variable "wins".
+
+## In-depth settings
+
+The documentation for the various options is split up in different sections.
+Please select the section that you're interested in or  find the desired
+setting in the [A-Z settings overview](settings-alphabetical).
 
 * [RabbitMQ settings](rabbitmq-config "RabbitmQ configuration")
 * [Cluster settings](cluster "Cluster configuration")

--- a/Mailerq/5.13/configuration.md
+++ b/Mailerq/5.13/configuration.md
@@ -43,7 +43,7 @@ In the rest of this documentation, we only denote the name of the configuration
 key as specified in the configuration file.
 
 The documentation for the various options is split up in different sections.
-Please select the section that you're interested in or  find the desired
+Please select the section that you're interested in or find the desired
 setting in the [A-Z settings overview](settings-alphabetical).
 
 * [RabbitMQ settings](rabbitmq-config "RabbitmQ configuration")

--- a/Mailerq/5.13/configuration.md
+++ b/Mailerq/5.13/configuration.md
@@ -35,7 +35,7 @@ MAILERQ_RABBITMQ_ADDRESS=amqp://rabbit.example.com mailerq
 ```
 
 The above will cause MailerQ to use `rabbit.example.com`. If you supply both,
-then the environment variable "wins".
+then the command-line override "wins".
 
 ## In-depth settings
 


### PR DESCRIPTION
It's possible to override configuration options via the command-line or environment variables, but this was not explained in the docs.