### PR TITLE
#39441 change html templates to e mail editor in recent documentation

### DIFF
--- a/Publisher/nl/email-editor-html-templates.md
+++ b/Publisher/nl/email-editor-html-templates.md
@@ -10,7 +10,7 @@ HTML-templates worden doorgaans gemaakt door webdesigners of programmeurs. Zij b
 
 ## Het aanmaken van een HTML-template
 
-Om een nieuwe HTML-template aan te maken navigeer je naar [**'HTML-templates'**](https://ms.copernica.com/#/design) en kies je voor **'Aanmaken'**, **'Template aanmaken'**. Zodra de template is aangemaakt voeg je de bijbehorende HTML-code toe, bijvoorbeeld:
+Om een nieuwe HTML-template aan te maken navigeer je naar [**'E-mail-editor'**](https://ms.copernica.com/#/design) en kies je voor **'Aanmaken'**, **'Template aanmaken'**. Zodra de template is aangemaakt voeg je de bijbehorende HTML-code toe, bijvoorbeeld:
 
 ``` 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/Publisher/nl/email-editor-html-templates.md
+++ b/Publisher/nl/email-editor-html-templates.md
@@ -10,7 +10,7 @@ HTML-templates worden doorgaans gemaakt door webdesigners of programmeurs. Zij b
 
 ## Het aanmaken van een HTML-template
 
-Om een nieuwe HTML-template aan te maken navigeer je naar [**'E-mail-editor'**](https://ms.copernica.com/#/design) en kies je voor **'Aanmaken'**, **'Template aanmaken'**. Zodra de template is aangemaakt voeg je de bijbehorende HTML-code toe, bijvoorbeeld:
+Om een nieuwe HTML-template aan te maken navigeer je naar [**'E-mail-editor'**](https://ms.copernica.com/#/design) en kies je voor **'Aanmaken'**, **'HTML-template aanmaken'**. Zodra de template is aangemaakt voeg je de bijbehorende HTML-code toe, bijvoorbeeld:
 
 ``` 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
@@ -27,7 +27,7 @@ Om een nieuwe HTML-template aan te maken navigeer je naar [**'E-mail-editor'**](
 </html>
 ```
 
-Vervolgens maak je een document aan die onder het aangemaakte template valt. Dat doe je via **'Aanmaken'**, **'Document aanmaken'**.  
+Vervolgens maak je een document aan die onder het aangemaakte template valt. Dat doe je via **'Aanmaken'**, **'HTML-document aanmaken'**.  
 
 Het bovenstaande voorbeeldtemplate bevat een tekstblok met de tekst "_voorbeeld_". Je kunt deze tekst binnen je document aanpassen door erop te klikken in de **'Hybridemodus'** of **'Bewerkmodus'**. Je vindt deze onderaan het document onder **'Weergave'** of in de toolbar van het document onder **'Blokken bewerken'**.
 

--- a/Publisher/nl/email-editor-send-mass-mailing.md
+++ b/Publisher/nl/email-editor-send-mass-mailing.md
@@ -1,5 +1,5 @@
 # Een bulkmailing versturen
-Het tegelijkertijd mailen van meerdere relaties wordt een bulkmailing genoemd. Je kunt een bulkmailing inplannen of direct versturen via de optie **'Mailing versturen'**. Je vindt deze in de toolbar bij **'[Profielen](https://ms.copernica.com/#/profiles)'** en **'[HTML-templates](https://ms.copernica.com/#/design)'**.
+Het tegelijkertijd mailen van meerdere relaties wordt een bulkmailing genoemd. Je kunt een bulkmailing inplannen of direct versturen via de optie **'Mailing versturen'**. Je vindt deze in de toolbar bij **'[Profielen](https://ms.copernica.com/#/profiles)'** en **'[E-mail-editor](https://ms.copernica.com/#/design)'**.
 
 Het versturen van een bulkmailing verloopt in drie stappen: 
 

--- a/Publisher/nl/first-login.md
+++ b/Publisher/nl/first-login.md
@@ -26,9 +26,8 @@ De modules zijn als volgt ingericht:
 ### Marketing Suite
 
 * __Dashboard:__ bevat algemene statistieken over verzonden mailings.  
-* __Profielen:__ hier beheer je databases en profielen ([meer informatie](./database-profiles)).  
-* __E-mail designer:__ bevat een [Drag-and-drop Editor](https://ms.copernica.com/#/templates) voor het opstellen van mailings.  
-* __HTML-templates:__ hier creëer je geavanceerde HTML-templates.  
+* __Profielen:__ hier beheer je databases en profielen ([meer informatie](./database-profiles)).    
+* __E-mail-editor:__ hier creëer je uitgebreide e-mailtemplates door middel van drag and drop of HTML. 
 * __Vormgeving - CSS:__ biedt mogelijkheden voor het beheren van CSS-opmaakbestanden.  
 * __Vormgeving - XSLT:__ biedt mogelijkheden voor het beheren van XSLT-opmaakbestanden.  
 * __Resultaten:__ hier bekijk je de resultaten van verzonden mailings en beheer je toekomstige mailings.  

--- a/Publisher/nl/first-mailing.md
+++ b/Publisher/nl/first-mailing.md
@@ -32,7 +32,7 @@ Je kunt de standaardselectie aanmaken door binnen je gekozen database te naviger
 _[Meer informatie over het aanbrengen van een selectiestructuur](./database-management)_.
 
 ## 5. E-mailopmaak
-Voordat je een e-mail kunt versturen is het nodig om eerst een template of document aan te maken. Met de [**'E-mail-editor'**](./design) ontwikkel je uitgebreide e-mailtemplates door middel van drag and drop of HTML. Je kunt daarbij gebruik maken van feeds, conditionele content en meer. 
+Voordat je een e-mail kunt versturen is het nodig om eerst een template of document aan te maken. Met de [**'E-mail-editor'**](https://ms.copernica.com/#/design) ontwikkel je uitgebreide e-mailtemplates door middel van drag and drop of HTML. Je kunt daarbij gebruik maken van feeds, conditionele content en meer. 
 
 _[Meer informatie over HTML-templates](./email-editor-html-templates)_.
 

--- a/Publisher/nl/first-mailing.md
+++ b/Publisher/nl/first-mailing.md
@@ -32,7 +32,7 @@ Je kunt de standaardselectie aanmaken door binnen je gekozen database te naviger
 _[Meer informatie over het aanbrengen van een selectiestructuur](./database-management)_.
 
 ## 5. E-mailopmaak
-Voordat je een e-mail kunt versturen is het nodig om eerst een template of document aan te maken. Met de [E-mail-editor](./design) ontwikkel je uitgebreide e-mailtemplates door middel van drag and drop of HTML. Je kunt daarbij gebruik maken van feeds, conditionele content en meer. 
+Voordat je een e-mail kunt versturen is het nodig om eerst een template of document aan te maken. Met de [**'E-mail-editor'**](./design) ontwikkel je uitgebreide e-mailtemplates door middel van drag and drop of HTML. Je kunt daarbij gebruik maken van feeds, conditionele content en meer. 
 
 _[Meer informatie over HTML-templates](./email-editor-html-templates)_.
 

--- a/Publisher/nl/first-mailing.md
+++ b/Publisher/nl/first-mailing.md
@@ -32,13 +32,9 @@ Je kunt de standaardselectie aanmaken door binnen je gekozen database te naviger
 _[Meer informatie over het aanbrengen van een selectiestructuur](./database-management)_.
 
 ## 5. E-mailopmaak
-Voordat je een e-mail kunt versturen is het nodig om eerst een template of document aan te maken. De [Drag-and-drop Editor](./templates) stelt je in staat om eenvoudig gepersonaliseerde templates met conditionele content te ontwikkelen en versturen. 
+Voordat je een e-mail kunt versturen is het nodig om eerst een template of document aan te maken. Met de [E-mail-editor](./design) ontwikkel je uitgebreide e-mailtemplates door middel van drag and drop of HTML. Je kunt daarbij gebruik maken van feeds, conditionele content en meer. 
 
-Het kan zijn dat je behoefte hebt aan meer flexibiliteit in het ontwikkelen van e-mailtemplates, bijvoorbeeld wanneer je templates dynamisch wilt opbouwen door middel van feeds. In zo’n geval maak je gebruik van [HTML-templates](./design). 
-
-_[Meer informatie over de Drag-and-drop Editor](./emailings-ms-templates)_.
-
-_[Meer informatie over HTML-templates](./emailings-publisher-templates)_.
+_[Meer informatie over HTML-templates](./email-editor-html-templates)_.
 
 ## 6. Verzending
 Het versturen van je eerste mailing vereist een verzendselectie (inclusief profielen), template en document. De voorgaande stappen helpen je bij het aanmaken daarvan. Heb je de checklist succesvol doorlopen? Je bent dan klaar om de mailing te versturen. 


### PR DESCRIPTION
Instances of 'HTML-templates' (as an outdated menu item) were changed to 'E-mail-editor' in recent documentation. Text referring to 'Template aanmaken' and 'Document aanmaken' was also changed to 'HTML-template aanmaken' and 'HTML-document aanmaken' to reflect changes in menu naming. Further outdated text was removed/edited in the process (project #39441).