### PR TITLE
Update MailerQ Rest API v1 poolip

### DIFF
--- a/Mailerq/5.13/rest-api-v1-pools.md
+++ b/Mailerq/5.13/rest-api-v1-pools.md
@@ -43,11 +43,11 @@ Content-Type: application/json
 
 [
     {
-        "ip": "127.0.0.1",
+        "localip": "127.0.0.1",
         "name": "sharedpool1"
     },
     {
-        "ip": "192.168.1.1",
+        "localip": "192.168.1.1",
         "name": "sharedpool1"
     }
 ]
@@ -95,7 +95,7 @@ Content-Type: application/json
 Authorization: Bearer ...
 
 {
-    "ip": "127.0.0.1",
+    "localip": "127.0.0.1",
     "name": "sharedpool1"
 },
 ```


### PR DESCRIPTION
The JSON example returned by the pool IP endpoint is different than the endpoint return.

A screenshot
![image](https://user-images.githubusercontent.com/355298/124481093-4cdb7280-dd7e-11eb-9b1a-4a38aefc8737.png)
