### PR TITLE
#54289] documentation check articles with database names with spaces

### DIFF
--- a/MS/en/databases/edit-collection-name.md
+++ b/MS/en/databases/edit-collection-name.md
@@ -1,4 +1,3 @@
 Use this form to edit the name of a collection.
 
-A name can contain alphanumeric characters and underscores. It can contain
-spaces as well, but it can't start or begin with a space.
+A name can contain alphanumeric characters and underscores.

--- a/MS/en/databases/edit-database-name.md
+++ b/MS/en/databases/edit-database-name.md
@@ -1,4 +1,3 @@
 Use this form to edit name and description of a database. 
 
-Name can contain alphanumeric characters and underscores. It can contain
-spaces as well, but it can't start or begin with a space.
+Name can contain alphanumeric characters and underscores.

--- a/Publisher/en/restv1/rest-post-databases.md
+++ b/Publisher/en/restv1/rest-post-databases.md
@@ -29,7 +29,7 @@ $api = new CopernicaRestApi("your-access-token");
 
 // data to be sent to the api
 $data = array(
-    'name'          =>  'my-test-database',
+    'name'          =>  'my_test_database',
     'description'   =>  'a description of the database'
 );
 

--- a/Publisher/en/restv2/rest-get-database.md
+++ b/Publisher/en/restv2/rest-get-database.md
@@ -43,7 +43,7 @@ The JSON for the database might look something like this:
 ```json
 {  
    "ID":"3144",
-   "name":"Test database",
+   "name":"Test_database",
    "description":"This is a test database.",
    "archived":false,
    "created":"2018-03-08 10:47:01",

--- a/Publisher/en/restv2/rest-get-databases.md
+++ b/Publisher/en/restv2/rest-get-databases.md
@@ -40,7 +40,7 @@ The JSON for a single database might look something like this:
 ```json
 {  
    "ID":"3144",
-   "name":"Test database",
+   "name":"Test_database",
    "description":"This is a test database.",
    "archived":false,
    "created":"2018-03-08 10:47:01",

--- a/Publisher/en/restv2/rest-post-databases.md
+++ b/Publisher/en/restv2/rest-post-databases.md
@@ -26,7 +26,7 @@ $api = new CopernicaRestAPI("your-access-token", 2);
 
 // data to be sent to the api
 $data = array(
-    'name'          =>  'my-test-database',
+    'name'          =>  'my_test_database',
     'description'   =>  'a description of the database'
 );
 

--- a/Publisher/en/restv3/rest-get-database.md
+++ b/Publisher/en/restv3/rest-get-database.md
@@ -43,7 +43,7 @@ The JSON for the database might look something like this:
 ```json
 {  
    "ID":"3144",
-   "name":"Test database",
+   "name":"Test_database",
    "description":"This is a test database.",
    "archived":false,
    "created":"2018-03-08 10:47:01",

--- a/Publisher/en/restv3/rest-get-databases.md
+++ b/Publisher/en/restv3/rest-get-databases.md
@@ -40,7 +40,7 @@ The JSON for a single database might look something like this:
 ```json
 {  
    "ID":"3144",
-   "name":"Test database",
+   "name":"Test_database",
    "description":"This is a test database.",
    "archived":false,
    "created":"2018-03-08 10:47:01",

--- a/Publisher/en/restv3/rest-post-databases.md
+++ b/Publisher/en/restv3/rest-post-databases.md
@@ -26,7 +26,7 @@ $api = new CopernicaRestAPI("your-access-token", 3);
 
 // data to be sent to the api
 $data = array(
-    'name'          =>  'my-test-database',
+    'name'          =>  'my_test_database',
     'description'   =>  'a description of the database'
 );
 

--- a/Publisher/nl/restv1/rest-post-databases.md
+++ b/Publisher/nl/restv1/rest-post-databases.md
@@ -29,7 +29,7 @@ $api = new CopernicaRestApi("your-access-token");
 
 // data voor de methode
 $data = array(
-    'name'          =>  'mijn-test-database',
+    'name'          =>  'mijn_test_database',
     'description'   =>  'omschrijving van de database'
 );
 

--- a/Publisher/nl/restv2/rest-get-database.md
+++ b/Publisher/nl/restv2/rest-get-database.md
@@ -43,7 +43,7 @@ De JSON voor een database ziet er bijvoorbeeld zo uit:
 ```json
 {  
    "ID":"3144",
-   "name":"Test database",
+   "name":"Test_database",
    "description":"This is a test database.",
    "archived":false,
    "created":"2018-03-08 10:47:01",

--- a/Publisher/nl/restv2/rest-get-databases.md
+++ b/Publisher/nl/restv2/rest-get-databases.md
@@ -42,7 +42,7 @@ De JSON voor een enkele database ziet er bijvoorbeeld zo uit:
 ```json
 {  
    "ID":"3144",
-   "name":"Test database",
+   "name":"Test_database",
    "description":"This is a test database.",
    "archived":false,
    "created":"2018-03-08 10:47:01",

--- a/Publisher/nl/restv2/rest-post-databases.md
+++ b/Publisher/nl/restv2/rest-post-databases.md
@@ -24,7 +24,7 @@ $api = new CopernicaRestAPI("your-access-token", 2);
 
 // data voor de methode
 $data = array(
-    'name'          =>  'mijn-test-database',
+    'name'          =>  'mijn_test_database',
     'description'   =>  'omschrijving van de database'
 );
 

--- a/Publisher/nl/restv3/rest-get-database.md
+++ b/Publisher/nl/restv3/rest-get-database.md
@@ -43,7 +43,7 @@ De JSON voor een database ziet er bijvoorbeeld zo uit:
 ```json
 {  
    "ID":"3144",
-   "name":"Test database",
+   "name":"Test_database",
    "description":"This is a test database.",
    "archived":false,
    "created":"2018-03-08 10:47:01",

--- a/Publisher/nl/restv3/rest-get-databases.md
+++ b/Publisher/nl/restv3/rest-get-databases.md
@@ -42,7 +42,7 @@ De JSON voor een enkele database ziet er bijvoorbeeld zo uit:
 ```json
 {  
    "ID":"3144",
-   "name":"Test database",
+   "name":"Test_database",
    "description":"This is a test database.",
    "archived":false,
    "created":"2018-03-08 10:47:01",

--- a/Publisher/nl/restv3/rest-post-databases.md
+++ b/Publisher/nl/restv3/rest-post-databases.md
@@ -24,7 +24,7 @@ $api = new CopernicaRestAPI("your-access-token", 3);
 
 // data voor de methode
 $data = array(
-    'name'          =>  'mijn-test-database',
+    'name'          =>  'mijn_test_database',
     'description'   =>  'omschrijving van de database'
 );
 


### PR DESCRIPTION
Two small changes because spaces are not allowed anymore. It's just the 'en' files because the 'nl' folder was already empty.