### PR TITLE
DO NOT MERGE : start/skip example

### DIFF
--- a/Publisher/en/restv3/rest-get-database-profiles.md
+++ b/Publisher/en/restv3/rest-get-database-profiles.md
@@ -14,7 +14,7 @@ to speed it up.
 
 The following parameters can be added to the URL as variables:
 
-* **start**: First ID to retrieve.
+* **start**: The amount of records to skip.
 * **limit**: Length of the batch.
 * **total**: Boolean. Indicates whether to show the total or not. Setting this to 'false' 
 will speed up the call.


### PR DESCRIPTION
Hey Copernicae,

When using this endpoint, it seems like the `start` parameter is used more like a `skip` parameter. I don't know if you are aware of this, but this causes some weird behavior.

# When using `start` param as an actual `start`:

```
2023-07-25 10:51:35.268  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : Total count 2050332
2023-07-25 10:51:35.292  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 1000, first ID = 87360, next ID = 88362
2023-07-25 10:51:36.676  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 2000, first ID = 242461, next ID = 243461
2023-07-25 10:51:38.742  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 3000, first ID = 397754, next ID = 398754
2023-07-25 10:51:41.354  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 4000, first ID = 553116, next ID = 554116
2023-07-25 10:51:44.868  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 5000, first ID = 709475, next ID = 710476
2023-07-25 10:51:51.964  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 6000, first ID = 865921, next ID = 866921
2023-07-25 10:52:00.997  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 7000, first ID = 1022462, next ID = 1023462
2023-07-25 10:52:10.256  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 8000, first ID = 1180684, next ID = 1181685
2023-07-25 10:52:21.062  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 9000, first ID = 1339033, next ID = 1340033
2023-07-25 10:52:32.472  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 10000, first ID = 1497599, next ID = 1498600
2023-07-25 10:52:44.282  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 11000, first ID = 1743219, next ID = 1744219
2023-07-25 10:52:58.045  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 12000, first ID = 2864004, next ID = 2865129
2023-07-25 10:53:13.899  INFO 21524 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 12000, first ID = null, next ID = null
12000
```

# When using the `start` param as a `skip`:

```
2023-07-25 10:56:47.501  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : Total count 2050339
2023-07-25 10:56:47.523  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 1000, first ID = 87360, next ID = 88362
2023-07-25 10:56:48.704  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 2000, first ID = 88362, next ID = 89362
2023-07-25 10:56:49.806  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 3000, first ID = 89362, next ID = 90363
2023-07-25 10:56:50.796  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 4000, first ID = 90363, next ID = 91364
2023-07-25 10:56:51.742  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 5000, first ID = 91364, next ID = 92365
2023-07-25 10:56:52.840  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 6000, first ID = 92365, next ID = 93365
2023-07-25 10:56:53.785  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 7000, first ID = 93365, next ID = 94365
2023-07-25 10:56:54.721  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 8000, first ID = 94365, next ID = 95365
2023-07-25 10:56:55.623  INFO 14396 --- [           main] c.b.v.c.c.copernica.CopernicaService     : total = 9000, first ID = 95365, next ID = 96365
... Goes on for a long time
```